### PR TITLE
Memory fixes

### DIFF
--- a/PhoenixSwiftClient/Channel.swift
+++ b/PhoenixSwiftClient/Channel.swift
@@ -45,56 +45,63 @@ public class Channel {
   var pushBuffer: [Push] = []
   var joinPush: Push? = nil
   var rejoinTimer: ConnectionTimer?
-  
+
   init(topic: String, params: Any?, socket: Socket) {
     self.topic = topic
     self.params = params
     self.socket = socket
-    timeout = socket.timeout
-    
+    self.timeout = socket.timeout
+
     // Set up join message and timers.
     joinPush = Push(channel: self, event: CHANNEL_EVENTS["join"]!, payload: params, timeout: timeout)
-    joinPush!.receive(status: "ok", callback: { (_: Any?) -> () in
-      self.state = ChannelState.joined
-      self.rejoinTimer?.reset()
-      self.pushBuffer.forEach { $0.send() }
-      self.pushBuffer.removeAll()
+    joinPush!.receive(status: "ok", callback: { [weak self] (_: Any?) -> () in
+      print("Joined room successfully! \(self?.topic)")
+      self?.state = ChannelState.joined
+      self?.rejoinTimer?.reset()
+      self?.pushBuffer.forEach { $0.send() }
+      self?.pushBuffer.removeAll()
+      self?.joinPush?.cancelTimeout()
     })
-    
-    joinPush!.receive(status: "timeout", callback: { (_: Any?) -> () in
-      //      self.socket.log("channel", "timeout \(topic)", joinPush.timeout)
-      self.state = ChannelState.errored
-      self.scheduleRejoinTimer()
+
+    joinPush!.receive(status: "timeout", callback: { [weak self] (_: Any?) -> () in
+      print("Timedout while joining room! \(self?.topic)")
+      //      self?.socket.log("channel", "timeout \(topic)", joinPush.timeout)
+      self?.state = ChannelState.errored
+      self?.scheduleRejoinTimer()
     })
 
     DispatchQueue.main.asyncAfter(deadline: .now()) {
       self.setChannelCallbacks()
     }
   }
-  
+
   deinit {
     rejoinTimer?.reset()
   }
-  
+
   private func setChannelCallbacks () {
     // Set up channel state callbacks and replies
-    on(event: CHANNEL_EVENTS["reply"]!, callback: { (payload: Any?, ref: Int?) in
-      let message = Message(topic: self.topic, event: self.replyEventName(ref: ref), payload: payload, ref: ref)
-      self.trigger(message: message)
+    on(event: CHANNEL_EVENTS["reply"]!, callback: { [weak self](payload: Any?, ref: Int?) in
+      if let chan = self {
+        let message = Message(topic: chan.topic, event: chan.replyEventName(ref: ref), payload: payload, ref: ref)
+        chan.trigger(message: message)
+      }
     })
-    
-    onClose(callback: { (_: Any?, _: Int?) -> () in
-      self.rejoinTimer?.reset()
-      //      self.socket.log("channel", "close \(topic) \(joinRef())")
-      self.state = ChannelState.closed
-      self.socket?.remove(channel: self)
+
+    onClose(callback: { [weak self](_: Any?, _: Int?) -> () in
+      if let chan = self {
+        chan.rejoinTimer?.reset()
+        //      chan.socket.log("channel", "close \(topic) \(joinRef())")
+        chan.state = ChannelState.closed
+        chan.socket?.remove(channel: chan)
+      }
     })
-    
-    onError(callback: { (reason: Any?, _: NSInteger?) -> () in
-      self.rejoinTimer?.reset()
-      //      self.socket.log("channel", "error \(topic)", reason)
-      self.state = ChannelState.errored
-      self.scheduleRejoinTimer()
+
+    onError(callback: { [weak self](reason: Any?, _: NSInteger?) -> () in
+      self?.rejoinTimer?.reset()
+      //      self?.socket.log("channel", "error \(topic)", reason)
+      self?.state = ChannelState.errored
+      self?.scheduleRejoinTimer()
     })
   }
 
@@ -102,89 +109,95 @@ public class Channel {
     if socket == nil {
       return
     }
-    
+
     if (rejoinTimer == nil) {
-      rejoinTimer = ConnectionTimer(callback: self.rejoinUntilConnected, timerCalc: socket!.reconnectAfterMs)
+      rejoinTimer = ConnectionTimer(callback: {[weak self] in self?.rejoinUntilConnected()}, timerCalc: socket!.reconnectAfterMs)
     }
-    
+
     rejoinTimer!.scheduleTimeout()
   }
-  
+
   @objc private func rejoinUntilConnected () {
-    print("Rejoining")
+    print("Rejoining \(topic)")
     scheduleRejoinTimer()
-    
+
     if (socket != nil && socket!.isConnected()) {
       rejoin(timeout: nil)
     }
   }
-  
+
   public func join(timeout: NSInteger?) -> Push? {
     if (joinedOnce) {
       // TODO: Throw error
       return nil
     }
-    
+
     joinedOnce = true
     rejoin(timeout: timeout ?? self.timeout)
-    
+
     return joinPush
   }
-  
+
   public func onClose(callback: @escaping (_: Any?, _: NSInteger?) -> ()) {
     on(event: CHANNEL_EVENTS["close"]!, callback: callback)
   }
-  
+
   public func onError(callback: @escaping (_: Any?, _: Int?) -> ()) {
     on(event: CHANNEL_EVENTS["error"]!, callback: callback)
   }
-  
+
   public func on(event: String, callback: @escaping (_: Any?, _: NSInteger?) -> ()) {
     bindings.append((event: event, callback: callback))
   }
-  
+
   public func off(event: String) {
     bindings = bindings.filter { $0.event != event }
   }
-  
+
   private func canPush() -> Bool {
     return socket != nil && socket!.isConnected() && isJoined()
   }
-  
+
   public func push(event: String, payload: Any?, timeout: NSInteger? = nil) -> Push? {
     if(!joinedOnce) {
       // Throw error
       return nil
     }
-    
+
     let pushEvent = Push(channel: self, event: event, payload: payload, timeout: timeout ?? self.timeout)
-    
+
     if canPush() {
       pushEvent.send()
     } else {
       pushEvent.startTimeout()
       pushBuffer.append(pushEvent)
     }
-    
+
     return pushEvent
   }
-  
+
   public func leave(timeout: NSInteger? = nil) -> Push {
-    func closeCallback (_: Any?) {
-      //      self.socket.log("channel", "leave \(topic)")
-      let message = Message(topic: topic, event: CHANNEL_EVENTS["close"]!, payload: "leave", ref: joinRef()!)
-      self.trigger(message: message)
+    let closeCallback = {[weak self] (_: Any?) in
+      if let chan = self {
+        //      chan.socket.log("channel", "leave \(topic)")
+        let message = Message(topic: chan.topic, event: CHANNEL_EVENTS["close"]!, payload: "leave", ref: chan.joinRef()!)
+        chan.trigger(message: message)
+      }
     }
 
-    state = ChannelState.leaving
+    self.state = ChannelState.leaving
     let leavePush = Push(channel: self, event: CHANNEL_EVENTS["leave"]!, payload: [:], timeout: timeout ?? self.timeout)
-    leavePush.receive(status: "ok", callback: closeCallback).receive(status: "timeout", callback: closeCallback)
+    let _ = leavePush.receive(status: "ok", callback: closeCallback).receive(status: "timeout", callback: closeCallback)
     leavePush.send()
-    
+
     if !canPush() {
       leavePush.trigger(status: "ok", response: [:])
     }
-    
+
+    self.joinPush?.cancelTimeout()
+    self.rejoinTimer?.reset()
+    self.rejoinTimer = nil
+
     return leavePush
   }
 
@@ -192,35 +205,35 @@ public class Channel {
   public func onMessage(event: String, payload: Any? = nil, ref: NSInteger? = nil) -> Any? {
     return payload
   }
-  
+
   public func isMember(topic: String) -> Bool{
     return self.topic == topic
   }
-  
+
   public func joinRef() -> NSInteger? {
     return joinPush?.ref
   }
-  
+
   private func sendJoin(timeout: NSInteger) {
     state = ChannelState.joining
-    joinPush!.resend(timeout: timeout)
+    joinPush?.resend(timeout: timeout)
   }
-  
+
   private func rejoin(timeout: NSInteger?) {
     if isLeaving() || state == ChannelState.joining {
       return
     }
-    
+
     sendJoin(timeout: timeout ?? self.timeout)
   }
-  
+
   public func trigger(message: Message) {
     let ref = message.ref
     let event = message.event
     if ref != nil && IGNORED_EVENTS.contains(event) && ref! != joinRef()! {
       return
     }
-    
+
     let handledPayload = onMessage(event: event, payload: message.payload, ref: ref)
     if message.payload != nil && handledPayload == nil {
       // TODO: Throw error
@@ -232,67 +245,32 @@ public class Channel {
       self.bindings.filter({ $0.event == event }).forEach { $0.callback(handledPayload ?? [:], ref) }
     }
   }
-  
+
   public func replyEventName(ref: NSInteger?) -> String {
     if ref == nil {
       return ""
     }
-    
+
     return "chan_reply_\(ref!)"
   }
-  
+
   public func isClosed() -> Bool {
     return state == ChannelState.closed
   }
-  
+
   public func isErrored() -> Bool {
     return state == ChannelState.errored
   }
-  
+
   public func isJoined() -> Bool {
     return state == ChannelState.joined
   }
-  
+
   public func isJoining() -> Bool {
     return state == ChannelState.joining
   }
-  
+
   public func isLeaving() -> Bool {
     return state == ChannelState.leaving
   }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/PhoenixSwiftClient/Push.swift
+++ b/PhoenixSwiftClient/Push.swift
@@ -22,16 +22,19 @@ public class Push {
   var ref: Int?
   var refEvent: String?
   var receivedResp: Response?
-  
+
   init(channel: Channel, event: String, payload: Any?, timeout: Int) {
     self.channel = channel
     self.event = event
     self.payload = payload
     self.timeout = timeout
   }
-  
+
   deinit {
     timeoutTimer?.invalidate()
+    timeoutTimer = nil
+    receivedResp = nil
+    channel = nil
   }
 
   internal func resend(timeout: Int) {
@@ -43,12 +46,12 @@ public class Push {
     sent = false
     send()
   }
-  
+
   public func send() {
     if (hasReceived(status: "timeout")) {
       return
     }
-    
+
     if let chan = channel {
       startTimeout()
       sent = true
@@ -59,46 +62,48 @@ public class Push {
       chan.socket?.push(message: message)
     }
   }
-  
+
   public func receive(status: String, callback: @escaping ([String: AnyObject]?) -> ()) -> Push {
     if hasReceived(status: status) {
       callback(receivedResp!.response)
     }
-    
+
     recHooks.append(RecHook(status: status, callback: callback))
     return self
   }
-  
+
   private func matchReceive(status: String, response: [String: AnyObject]?) {
     recHooks.filter({ $0.status == status }).forEach { $0.callback(response) }
   }
-  
+
   private func cancelRefEvent() {
     if let event = refEvent, let chan = channel {
       chan.off(event: event)
     }
   }
-  
+
   internal func cancelTimeout () {
     if let timer = timeoutTimer {
       timer.invalidate()
     }
   }
-  
+
   internal func startTimeout () {
     if timeoutTimer != nil && timeoutTimer!.isValid {
       return
     }
-    
-    func handlePayload(incomingPayload: Any?, _: Int?) {
-      cancelRefEvent()
-      cancelTimeout()
-      
-      let response = Response(payload: incomingPayload as! [String: AnyObject])
-      receivedResp = response
-      matchReceive(status: response.status, response: response.response)
+
+    let handlePayload = {[weak self] (incomingPayload: Any?, _: Int?) in
+      if let push = self {
+        push.cancelRefEvent()
+        push.cancelTimeout()
+
+        let response = Response(payload: incomingPayload as! [String: AnyObject])
+        push.receivedResp = response
+        push.matchReceive(status: response.status, response: response.response)
+      }
     }
-    
+
     if let chan = channel, let socket = chan.socket {
       ref = socket.makeRef()
       refEvent = chan.replyEventName(ref: ref)
@@ -107,15 +112,15 @@ public class Push {
       timeoutTimer = Timer.scheduledTimer(timeInterval: Double(timeout) / 1000, target: self, selector: #selector(handleTimeout), userInfo: nil, repeats: false)
     }
   }
-  
+
   private func hasReceived(status: String) -> Bool {
     return receivedResp != nil && receivedResp!.status == status
   }
-  
+
   @objc func handleTimeout(_:Timer) {
     trigger(status: "timeout", response: [:])
   }
-  
+
   internal func trigger(status: String, response: Any?) {
     if let chan = channel, let event = refEvent {
       let payload = ["status": status, "response": response]


### PR DESCRIPTION
In callbacks we were often holding strong references which caused
reference cycles and prevented objects from being deinitialized.

Also the Socket reconnectTimer needed to be explicitly set to nil in the
Socket.disconnect() function